### PR TITLE
chore: export items in internal interface

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -59,7 +59,9 @@ func getDefaultKeys() (*rsa.PrivateKey, error) {
 //
 // Use NewDialer to initialize a Dialer.
 type Dialer struct {
-	lock           sync.RWMutex
+	lock sync.RWMutex
+	// instances map connection names (e.g., my-project:us-central1:my-instance)
+	// to *cloudsql.Instance types.
 	instances      map[string]*cloudsql.Instance
 	key            *rsa.PrivateKey
 	refreshTimeout time.Duration

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -87,13 +86,6 @@ func TestDialerInstantiationErrors(t *testing.T) {
 	}
 }
 
-func errorContains(err error, want string) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), want)
-}
-
 func TestDialWithAdminAPIErrors(t *testing.T) {
 	inst := mock.NewFakeCSQLInstance("my-project", "my-region", "my-instance")
 	mc, url, cleanup := mock.HTTPClient()
@@ -116,7 +108,7 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 
 	// instance name is bad
 	_, err = d.Dial(context.Background(), "bad-instance-name")
-	if !errorContains(err, "invalid instance") {
+	if !mock.ErrorContains(err, "invalid instance") {
 		t.Fatalf("expected Dial to fail with bad instance name, but it succeeded.")
 	}
 
@@ -131,7 +123,7 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 
 	// failed to retrieve metadata or ephemeral cert (not registered in the mock)
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	if !errorContains(err, "fetch metadata failed") {
+	if !mock.ErrorContains(err, "fetch metadata failed") {
 		t.Fatalf("expected Dial to fail with missing metadata")
 	}
 }
@@ -158,13 +150,13 @@ func TestDialWithConfigurationErrors(t *testing.T) {
 
 	// when failing to find private IP for public-only instance
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance", WithPrivateIP())
-	if !errorContains(err, "does not have IP of type") {
+	if !mock.ErrorContains(err, "does not have IP of type") {
 		t.Fatalf("expected Dial to fail with missing metadata")
 	}
 
 	// when Dialing TCP socket fails (no server proxy running)
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	if !errorContains(err, "connection refused") {
+	if !mock.ErrorContains(err, "connection refused") {
 		t.Fatalf("expected Dial to fail with connection error")
 	}
 
@@ -174,7 +166,7 @@ func TestDialWithConfigurationErrors(t *testing.T) {
 
 	// when TLS handshake fails
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	if !errorContains(err, "handshake failed") {
+	if !mock.ErrorContains(err, "handshake failed") {
 		t.Fatalf("expected Dial to fail with connection error")
 	}
 }

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -133,7 +133,11 @@ type Instance struct {
 }
 
 // NewInstance initializes a new Instance given an instance connection name
-func NewInstance(cn ConnName, client *sqladmin.Service, key *rsa.PrivateKey, refreshTimeout time.Duration) *Instance {
+func NewInstance(connName string, client *sqladmin.Service, key *rsa.PrivateKey, refreshTimeout time.Duration) (*Instance, error) {
+	cn, err := NewConnName(connName)
+	if err != nil {
+		return nil, err
+	}
 	i := &Instance{
 		ConnName: cn,
 		key:      key,
@@ -150,7 +154,7 @@ func NewInstance(cn ConnName, client *sqladmin.Service, key *rsa.PrivateKey, ref
 	i.cur = i.scheduleRefresh(0)
 	i.next = i.cur
 	i.resultGuard.Unlock()
-	return i
+	return i, nil
 }
 
 // ConnectInfo returns an IP address specified by ipType (i.e., public or

--- a/internal/cloudsql/instance_test.go
+++ b/internal/cloudsql/instance_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cloudsql
+package cloudsql_test
 
 import (
 	"context"
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/cloudsqlconn/internal/cloudsql"
 	"cloud.google.com/cloudsqlconn/internal/mock"
 	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
@@ -30,25 +31,25 @@ import (
 func TestParseConnName(t *testing.T) {
 	tests := []struct {
 		name string
-		want connName
+		want cloudsql.ConnName
 	}{
 		{
 			"project:region:instance",
-			connName{"project", "region", "instance"},
+			cloudsql.ConnName{"project", "region", "instance"},
 		},
 		{
 			"google.com:project:region:instance",
-			connName{"google.com:project", "region", "instance"},
+			cloudsql.ConnName{"google.com:project", "region", "instance"},
 		},
 		{
 			"project:instance", // missing region
-			connName{},
+			cloudsql.ConnName{},
 		},
 	}
 
 	for _, tc := range tests {
-		c, err := parseConnName(tc.name)
-		if err != nil && tc.want != (connName{}) {
+		c, err := cloudsql.NewConnName(tc.name)
+		if err != nil && tc.want != (cloudsql.ConnName{}) {
 			t.Errorf("unexpected error: %e", err)
 		}
 		if c != tc.want {
@@ -61,11 +62,11 @@ func TestConnectInfo(t *testing.T) {
 	ctx := context.Background()
 
 	// define some test instance settings
-	cn, err := parseConnName("my-proj:my-region:my-inst")
+	cn, err := cloudsql.NewConnName("my-proj:my-region:my-inst")
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	inst := mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name)
+	inst := mock.NewFakeCSQLInstance(cn.Project, cn.Region, cn.Name)
 
 	// mock expected requests
 	mc, url, cleanup := mock.HTTPClient(
@@ -89,12 +90,9 @@ func TestConnectInfo(t *testing.T) {
 		t.Fatalf("failed to generate keys: %v", err)
 	}
 
-	im, err := NewInstance(cn.String(), client, key, 30*time.Second)
-	if err != nil {
-		t.Fatalf("failed to initialize Instance: %v", err)
-	}
+	im := cloudsql.NewInstance(cn, client, key, 30*time.Second)
 
-	_, _, err = im.ConnectInfo(ctx)
+	_, _, err = im.ConnectInfo(ctx, cloudsql.PublicIP)
 	if err != nil {
 		t.Fatalf("failed to retrieve connect info: %v", err)
 	}
@@ -121,13 +119,17 @@ func TestRefreshTimeout(t *testing.T) {
 		t.Fatalf("failed to generate keys: %v", err)
 	}
 
+	cn, err := cloudsql.NewConnName("my-proj:my-region:my-inst")
+	if err != nil {
+		t.Fatalf("expected valid conn name, got error: %v", err)
+	}
 	// Use a timeout that should fail instantly
-	im, err := NewInstance("my-proj:my-region:my-inst", client, key, 0)
+	im := cloudsql.NewInstance(cn, client, key, 0)
 	if err != nil {
 		t.Fatalf("failed to initialize Instance: %v", err)
 	}
 
-	_, _, err = im.ConnectInfo(ctx)
+	_, _, err = im.ConnectInfo(ctx, cloudsql.PublicIP)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("failed to retrieve connect info: %v", err)
 	}

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -152,7 +152,8 @@ func createTLSConfig(inst ConnName, m Metadata, cert tls.Certificate) *tls.Confi
 
 // verifyPeerCertFunc creates a VerifyPeerCertificate func that verifies that the peer
 // certificate is in the cert pool. We need to define our own because CloudSQL
-// instances use self-signed certificates as a RootCA.
+// instances use the instance name (e.g., my-project:my-instance) instead of a
+// valid domain name for the certificate's Common Name.
 func verifyPeerCertFunc(cn ConnName, pool *x509.CertPool) func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if len(rawCerts) == 0 {

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -29,11 +29,11 @@ func TestFetchMetadata(t *testing.T) {
 	ctx := context.Background()
 
 	// define some test instance settings
-	cn, err := parseConnName("my-proj:my-region:my-inst")
+	cn, err := NewConnName("my-proj:my-region:my-inst")
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	inst := mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name)
+	inst := mock.NewFakeCSQLInstance(cn.Project, cn.Region, cn.Name)
 
 	// mock expected requests
 	mc, url, cleanup := mock.HTTPClient(
@@ -59,11 +59,11 @@ func TestFetchEphemeralCert(t *testing.T) {
 	ctx := context.Background()
 
 	// define some test instance settings
-	cn, err := parseConnName("my-proj:my-region:my-inst")
+	cn, err := NewConnName("my-proj:my-region:my-inst")
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	inst := mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name)
+	inst := mock.NewFakeCSQLInstance(cn.Project, cn.Region, cn.Name)
 
 	// mock expected requests
 	mc, url, cleanup := mock.HTTPClient(

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -32,9 +32,9 @@ func TestRefresh(t *testing.T) {
 	wantIP := "127.0.0.1"
 	wantExpiry := time.Now().Add(time.Hour).UTC().Round(time.Second)
 	wantConnName := "my-project:my-region:my-instance"
-	cn, _ := cloudsql.NewConnName(wantConnName)
+	cn, err := cloudsql.NewConnName(wantConnName)
 	client, cleanup, err := mock.TestClient(
-		cn,
+		"my-project", "my-region", "my-instance",
 		&sqladmin.DatabaseInstance{IpAddresses: []*sqladmin.IpMapping{{IpAddress: "127.0.0.1", Type: "PRIMARY"}}},
 		wantExpiry,
 	)
@@ -68,7 +68,7 @@ func TestRefresh(t *testing.T) {
 func TestRefreshFailsFast(t *testing.T) {
 	cn, _ := cloudsql.NewConnName("my-project:my-region:my-instance")
 	client, cleanup, err := mock.TestClient(
-		cn,
+		"my-project", "my-region", "my-instance",
 		&sqladmin.DatabaseInstance{
 			IpAddresses: []*sqladmin.IpMapping{
 				{IpAddress: "127.0.0.1", Type: "PRIMARY"},

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -12,80 +12,318 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cloudsql
+package cloudsql_test
 
 import (
+	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
+	"encoding/pem"
+	"errors"
 	"testing"
+	"time"
 
+	"cloud.google.com/cloudsqlconn/internal/cloudsql"
 	"cloud.google.com/cloudsqlconn/internal/mock"
 	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
-func TestFetchMetadata(t *testing.T) {
-	ctx := context.Background()
-
-	// define some test instance settings
-	cn, err := NewConnName("my-proj:my-region:my-inst")
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	inst := mock.NewFakeCSQLInstance(cn.Project, cn.Region, cn.Name)
-
-	// mock expected requests
-	mc, url, cleanup := mock.HTTPClient(
-		mock.InstanceGetSuccess(inst, 1),
+func TestRefresh(t *testing.T) {
+	wantIP := "127.0.0.1"
+	wantExpiry := time.Now().Add(time.Hour).UTC().Round(time.Second)
+	wantConnName := "my-project:my-region:my-instance"
+	cn, _ := cloudsql.NewConnName(wantConnName)
+	client, cleanup, err := mock.TestClient(
+		cn,
+		&sqladmin.DatabaseInstance{IpAddresses: []*sqladmin.IpMapping{{IpAddress: "127.0.0.1", Type: "PRIMARY"}}},
+		wantExpiry,
 	)
-	defer func() {
-		if err := cleanup(); err != nil {
-			t.Fatalf("%v", err)
-		}
-	}()
-
-	client, err := sqladmin.NewService(ctx, option.WithHTTPClient(mc), option.WithEndpoint(url))
 	if err != nil {
-		t.Fatalf("client init failed: %s", err)
+		t.Fatalf("failed to create test SQL admin service: %s", err)
+	}
+	defer cleanup()
+
+	r := cloudsql.NewRefresher(time.Hour, 30*time.Second, 2, client)
+	md, tlsCfg, gotExpiry, err := r.PerformRefresh(context.Background(), cn, mock.RSAKey)
+	if err != nil {
+		t.Fatalf("PerformRefresh unexpectedly failed with error: %v", err)
 	}
 
-	_, err = fetchMetadata(ctx, client, cn)
-	if err != nil {
-		t.Fatalf("%s", err)
+	gotIP, ok := md.IPAddrs[cloudsql.PublicIP]
+	if !ok {
+		t.Fatalf("metadata IP addresses did not include public address")
+	}
+	if wantIP != gotIP {
+		t.Fatalf("metadata IP mismatch, want = %v, got = %v", wantIP, gotIP)
+	}
+	if wantExpiry != gotExpiry {
+		t.Fatalf("expiry mismatch, want = %v, got = %v", wantExpiry, gotExpiry)
+	}
+
+	if wantConnName != tlsCfg.ServerName {
+		t.Fatalf("server name mismatch, want = %v, got = %v", wantConnName, tlsCfg.ServerName)
 	}
 }
-func TestFetchEphemeralCert(t *testing.T) {
-	ctx := context.Background()
 
-	// define some test instance settings
-	cn, err := NewConnName("my-proj:my-region:my-inst")
+func TestRefreshFailsFast(t *testing.T) {
+	cn, _ := cloudsql.NewConnName("my-project:my-region:my-instance")
+	client, cleanup, err := mock.TestClient(
+		cn,
+		&sqladmin.DatabaseInstance{
+			IpAddresses: []*sqladmin.IpMapping{
+				{IpAddress: "127.0.0.1", Type: "PRIMARY"},
+				{IpAddress: "0.0.0.0", Type: "PRIVATE"},
+			}},
+		time.Now().Add(time.Hour),
+	)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatalf("failed to create test SQL admin service: %s", err)
 	}
+	defer cleanup()
+
+	r := cloudsql.NewRefresher(time.Hour, 30*time.Second, 1, client)
+	_, _, _, err = r.PerformRefresh(context.Background(), cn, mock.RSAKey)
+	if err != nil {
+		t.Fatalf("expected no error, got = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// context is canceled
+	_, _, _, err = r.PerformRefresh(ctx, cn, mock.RSAKey)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled error, got = %v", err)
+	}
+
+	// force the rate limiter to throttle with a timed out context
+	ctx, _ = context.WithTimeout(context.Background(), time.Millisecond)
+	_, _, _, err = r.PerformRefresh(ctx, cn, mock.RSAKey)
+
+	if !mock.ErrorContains(err, "throttled") {
+		t.Fatalf("expected throttled error, got = %v", err)
+	}
+}
+
+func invalidCertPEM() string {
+	certPEM := &bytes.Buffer{}
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: []byte("hello"), // woops no cert
+	})
+	return certPEM.String()
+}
+
+func TestRefreshWithFailedMetadataCall(t *testing.T) {
+	cn, _ := cloudsql.NewConnName("my-project:my-region:my-instance")
 	inst := mock.NewFakeCSQLInstance(cn.Project, cn.Region, cn.Name)
 
-	// mock expected requests
-	mc, url, cleanup := mock.HTTPClient(
-		mock.CreateEphemeralSuccess(inst, 1),
-	)
-	defer func() {
-		if err := cleanup(); err != nil {
-			t.Fatalf("%v", err)
+	testCases := []struct {
+		req     *mock.Request
+		wantErr string
+		desc    string
+	}{
+		{
+			req:     mock.CreateEphemeralSuccess(inst, 1), // not a metadata call
+			wantErr: "failed to get instance",
+			desc:    "When the Metadata call fails",
+		},
+		{
+			req: mock.InstanceGetSuccessWithDatabase(inst, 1,
+				&sqladmin.DatabaseInstance{Region: "some-other-region"}),
+			wantErr: "region was mismatched",
+			desc:    "When the region does not match",
+		},
+		{
+			req: mock.InstanceGetSuccessWithDatabase(inst, 1,
+				&sqladmin.DatabaseInstance{
+					Region:      "my-region",
+					BackendType: "NOT_SECOND_GEN",
+				}),
+			wantErr: "only Second Generation",
+			desc:    "When the instance isn't Second generation",
+		},
+		{
+			req: mock.InstanceGetSuccessWithDatabase(inst, 1,
+				&sqladmin.DatabaseInstance{
+					Region:      "my-region",
+					BackendType: "SECOND_GEN",
+					// No IP addresss
+					IpAddresses: []*sqladmin.IpMapping{},
+				}),
+			wantErr: "no supported IP addresses",
+			desc:    "When the instance has no supported IP addresses",
+		},
+		{
+			req: mock.InstanceGetSuccessWithDatabase(inst, 1,
+				&sqladmin.DatabaseInstance{
+					Region:      "my-region",
+					BackendType: "SECOND_GEN",
+					IpAddresses: []*sqladmin.IpMapping{{IpAddress: "0.0.0.0", Type: "PRIMARY"}},
+					// No ServerCaCert
+					ServerCaCert: &sqladmin.SslCert{},
+				}),
+			wantErr: "failed to decode",
+			desc:    "When the server cert does not decode",
+		},
+		{
+			req: mock.InstanceGetSuccessWithDatabase(inst, 1,
+				&sqladmin.DatabaseInstance{
+					Region:       "my-region",
+					BackendType:  "SECOND_GEN",
+					IpAddresses:  []*sqladmin.IpMapping{{IpAddress: "0.0.0.0", Type: "PRIMARY"}},
+					ServerCaCert: &sqladmin.SslCert{Cert: invalidCertPEM()},
+				}),
+			wantErr: "failed to parse",
+			desc:    "When the cert is not a valid X.509 cert",
+		},
+	}
+	for i, tc := range testCases {
+		mc, url, cleanup := mock.HTTPClient(mock.CreateEphemeralSuccess(inst, 1), tc.req)
+		client, err := sqladmin.NewService(
+			context.Background(),
+			option.WithHTTPClient(mc),
+			option.WithEndpoint(url),
+		)
+		if err != nil {
+			t.Fatalf("failed to create test SQL admin service: %s", err)
 		}
-	}()
+		defer cleanup()
 
-	client, err := sqladmin.NewService(ctx, option.WithHTTPClient(mc), option.WithEndpoint(url))
-	if err != nil {
-		t.Fatalf("client init failed: %s", err)
+		r := cloudsql.NewRefresher(time.Hour, 30*time.Second, 1, client)
+		_, _, _, err = r.PerformRefresh(context.Background(), cn, mock.RSAKey)
+
+		if !mock.ErrorContains(err, tc.wantErr) {
+			t.Errorf("[%v] PerformRefresh failed with unexpected error, want = %v, got = %v", i, tc.wantErr, err)
+		}
 	}
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+}
+
+func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
+	cn, _ := cloudsql.NewConnName("my-project:my-region:my-instance")
+	inst := mock.NewFakeCSQLInstance(cn.Project, cn.Region, cn.Name)
+
+	testCases := []struct {
+		req     *mock.Request
+		wantErr string
+		desc    string
+	}{
+		{
+			req:     mock.InstanceGetSuccess(inst, 1), // not an ephemeral cert call
+			wantErr: "create failed",
+			desc:    "When the CreateEphemeralCert call fails",
+		},
+	}
+	for i, tc := range testCases {
+		mc, url, cleanup := mock.HTTPClient(mock.InstanceGetSuccess(inst, 1), tc.req)
+		client, err := sqladmin.NewService(
+			context.Background(),
+			option.WithHTTPClient(mc),
+			option.WithEndpoint(url),
+		)
+		if err != nil {
+			t.Fatalf("failed to create test SQL admin service: %s", err)
+		}
+		defer cleanup()
+
+		r := cloudsql.NewRefresher(time.Hour, 30*time.Second, 1, client)
+		_, _, _, err = r.PerformRefresh(context.Background(), cn, mock.RSAKey)
+
+		if !mock.ErrorContains(err, tc.wantErr) {
+			t.Errorf("[%v] PerformRefresh failed with unexpected error, want = %v, got = %v", i, tc.wantErr, err)
+		}
+	}
+}
+
+func TestRefreshBuildsTLSConfig(t *testing.T) {
+	wantServerName := "my-project:my-region:my-instance"
+	cn, _ := cloudsql.NewConnName(wantServerName)
+	inst := mock.NewFakeCSQLInstance(cn.Project, cn.Region, cn.Name)
+	certBytes := mock.CreateCertificate(inst)
+	mc, url, cleanup := mock.HTTPClient(
+		mock.InstanceGetSuccessWithDatabase(inst, 1,
+			&sqladmin.DatabaseInstance{
+				IpAddresses: []*sqladmin.IpMapping{
+					{IpAddress: "127.0.0.1", Type: "PRIMARY"},
+					{IpAddress: "0.0.0.0", Type: "PRIVATE"},
+				},
+				ServerCaCert: &sqladmin.SslCert{
+					Cert: string(certBytes),
+				},
+			},
+		),
+		mock.CreateEphemeralSuccessWithExpiry(inst, 1, time.Now().Add(time.Hour)),
+	)
+	defer cleanup()
+	client, err := sqladmin.NewService(
+		context.Background(),
+		option.WithHTTPClient(mc),
+		option.WithEndpoint(url),
+	)
 	if err != nil {
-		t.Fatalf("failed to generate keys: %v", err)
+		t.Fatalf("failed to create test SQL admin service: %s", err)
 	}
 
-	_, err = fetchEphemeralCert(ctx, client, cn, key)
+	r := cloudsql.NewRefresher(time.Hour, 30*time.Second, 1, client)
+	_, tlsCfg, _, err := r.PerformRefresh(context.Background(), cn, mock.RSAKey)
 	if err != nil {
-		t.Fatalf("failed to fetch ephemeral cert: %v", err)
+		t.Fatalf("expected no error, got = %v", err)
+	}
+
+	if wantServerName != tlsCfg.ServerName {
+		t.Fatalf(
+			"TLS config has incorrect server name, want = %v, got = %v",
+			wantServerName, tlsCfg.ServerName,
+		)
+	}
+
+	wantCertLen := 1
+	if wantCertLen != len(tlsCfg.Certificates) {
+		t.Fatalf(
+			"TLS config has unexpected number of certificates, want = %v, got = %v",
+			wantCertLen, len(tlsCfg.Certificates),
+		)
+	}
+
+	wantInsecure := true
+	if wantInsecure != tlsCfg.InsecureSkipVerify {
+		t.Fatalf(
+			"TLS config should skip verification, want = %v, got = %v",
+			wantInsecure, tlsCfg.InsecureSkipVerify,
+		)
+	}
+
+	if tlsCfg.RootCAs == nil {
+		t.Fatal("TLS config should include RootCA, got nil")
+	}
+
+	verifyPeerCert := tlsCfg.VerifyPeerCertificate
+	b, _ := pem.Decode(certBytes)
+	err = verifyPeerCert([][]byte{b.Bytes}, nil)
+	if err != nil {
+		t.Fatalf("expected to verify peer cert, got error: %v", err)
+	}
+
+	err = verifyPeerCert(nil, nil)
+	if !mock.ErrorContains(err, "no certificate") {
+		t.Fatalf("expected verify peer cert to fail, got = %v", err)
+	}
+
+	err = verifyPeerCert([][]byte{[]byte("not a cert")}, nil)
+	if !mock.ErrorContains(err, "x509.ParseCertificate(rawCerts[0])") {
+		t.Fatalf("expected verify peer cert to fail on invalid cert, got = %v", err)
+	}
+
+	badCert := mock.GenerateCertWithCommonName(inst, "wrong:wrong")
+	err = verifyPeerCert([][]byte{badCert}, nil)
+	if !mock.ErrorContains(err, "certificate had CN") {
+		t.Fatalf("expected common name mistmatch to error, got = %v", err)
+	}
+
+	other := mock.NewFakeCSQLInstance(cn.Project, cn.Region, cn.Name)
+	certBytes = mock.CreateCertificate(other)
+	b, _ = pem.Decode(certBytes)
+	err = verifyPeerCert([][]byte{b.Bytes}, nil)
+	if !mock.ErrorContains(err, "signed by unknown authority") {
+		t.Fatalf("expected certificate verification to fail, got = %v", err)
 	}
 }

--- a/internal/mock/sqladmin.go
+++ b/internal/mock/sqladmin.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/cloudsqlconn/internal/cloudsql"
 	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
@@ -269,8 +268,8 @@ func CreateEphemeralSuccess(i FakeCSQLInstance, ct int) *Request {
 
 // TestClient is a convenience wrapper that configures a mock HTTP client and
 // sqladmin.Service based on a connection name.
-func TestClient(cn cloudsql.ConnName, db *sqladmin.DatabaseInstance, certExpiry time.Time) (*sqladmin.Service, func() error, error) {
-	inst := NewFakeCSQLInstance(cn.Project, cn.Region, cn.Name)
+func TestClient(proj, reg, name string, db *sqladmin.DatabaseInstance, certExpiry time.Time) (*sqladmin.Service, func() error, error) {
+	inst := NewFakeCSQLInstance(proj, reg, name)
 	mc, url, cleanup := HTTPClient(
 		InstanceGetSuccessWithDatabase(inst, 1, db),
 		CreateEphemeralSuccessWithExpiry(inst, 1, certExpiry),


### PR DESCRIPTION
To improve testability, this commit exports a number of things within
the internal interface. All the exported things remain internal and
cannot be used outside the package.

- Export cloudsql.ConnName and use it in place of raw strings
- Hide IP Address type lookup inside cloudsql.Instance
- Export cloudsql.Metadata and its fields
- Export Refresher and r.PerformRefresh
- Rename genVerifyPeerCertificateFunc to verifyPeerCertFunc

All these changes (except the rename) will make it possible to improve
test coverage.