### PR TITLE
Increase coverage of refresh logic

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -137,8 +137,8 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 }
 
 func TestDialWithConfigurationErrors(t *testing.T) {
-	inst := mock.NewFakeCSQLInstance("my-project", "my-region", "my-instance")
-	inst.Cert.NotAfter = time.Now().Add(-time.Hour)
+	inst := mock.NewFakeCSQLInstance("my-project", "my-region", "my-instance",
+		mock.WithCertExpiry(time.Now().Add(-time.Hour)))
 	mc, url, cleanup := mock.HTTPClient(
 		mock.InstanceGetSuccess(inst, 2),
 		mock.CreateEphemeralSuccess(inst, 2),

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -23,8 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/time/rate"
-
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
@@ -143,11 +141,12 @@ func NewInstance(instance string, client *sqladmin.Service, key *rsa.PrivateKey,
 	i := &Instance{
 		connName: cn,
 		key:      key,
-		r: refresher{
-			timeout:       refreshTimeout,
-			clientLimiter: rate.NewLimiter(rate.Every(30*time.Second), 2),
-			client:        client,
-		},
+		r: newRefresher(
+			refreshTimeout,
+			30*time.Second,
+			2,
+			client,
+		),
 		ctx:    ctx,
 		cancel: cancel,
 	}

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -110,7 +110,7 @@ func fetchEphemeralCert(ctx context.Context, client *sqladmin.Service, inst conn
 	}
 	resp, err := client.SslCerts.CreateEphemeral(inst.project, inst.name, &req).Context(ctx).Do()
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("create failed: %w", err)
+		return tls.Certificate{}, fmt.Errorf("create ephemeral cert failed: %w", err)
 	}
 
 	// parse the client cert

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -110,7 +110,7 @@ func fetchEphemeralCert(ctx context.Context, client *sqladmin.Service, inst conn
 	}
 	resp, err := client.SslCerts.CreateEphemeral(inst.project, inst.name, &req).Context(ctx).Do()
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("create ephemeral failed: %w", err)
+		return tls.Certificate{}, fmt.Errorf("create failed: %w", err)
 	}
 
 	// parse the client cert
@@ -154,10 +154,11 @@ func createTLSConfig(inst connName, m metadata, cert tls.Certificate) *tls.Confi
 }
 
 // genVerifyPeerCertificateFunc creates a VerifyPeerCertificate func that verifies that the peer
-// certificate is in the cert pool. We need to define our own because of our sketchy non-standard
-// CNs.
-func genVerifyPeerCertificateFunc(cn connName, pool *x509.CertPool) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+// certificate is in the cert pool. We need to define our own because CloudSQL
+// instances use the instance name (e.g., my-project:my-instance) instead of a
+// valid domain name for the certificate's Common Name.
+func genVerifyPeerCertificateFunc(cn connName, pool *x509.CertPool) func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if len(rawCerts) == 0 {
 			return fmt.Errorf("no certificate to verify")
 		}
@@ -180,6 +181,17 @@ func genVerifyPeerCertificateFunc(cn connName, pool *x509.CertPool) func(rawCert
 	}
 }
 
+// newRefresher creates a Refresher.
+func newRefresher(timeout time.Duration, interval time.Duration, burst int, svc *sqladmin.Service) refresher {
+	return refresher{
+		timeout:       timeout,
+		clientLimiter: rate.NewLimiter(rate.Every(interval), burst),
+		client:        svc,
+	}
+}
+
+// refresher manages the SQL Admin API access to instance metadata and to
+// ephemeral certificates.
 type refresher struct {
 	// timeout is the maximum amount of time a refresh operation should be allowed to take.
 	timeout time.Duration

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -173,7 +173,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 				mock.NewFakeCSQLInstance(
 					cn.project, cn.region, cn.name,
 					mock.WithRegion("my-region"),
-					mock.WithSigner(func(_ *x509.Certificate, _ *rsa.PrivateKey) ([]byte, error) {
+					mock.WithCertSigner(func(_ *x509.Certificate, _ *rsa.PrivateKey) ([]byte, error) {
 						return nil, nil
 					}),
 				), 1),
@@ -185,7 +185,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 				mock.NewFakeCSQLInstance(
 					cn.project, cn.region, cn.name,
 					mock.WithRegion("my-region"),
-					mock.WithSigner(func(_ *x509.Certificate, _ *rsa.PrivateKey) ([]byte, error) {
+					mock.WithCertSigner(func(_ *x509.Certificate, _ *rsa.PrivateKey) ([]byte, error) {
 						certPEM := &bytes.Buffer{}
 						pem.Encode(certPEM, &pem.Block{
 							Type:  "CERTIFICATE",
@@ -200,11 +200,9 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			mc, url, cleanup := mock.HTTPClient(tc.req)
-			client, err := sqladmin.NewService(
+			client, cleanup, err := mock.NewSQLAdminService(
 				context.Background(),
-				option.WithHTTPClient(mc),
-				option.WithEndpoint(url),
+				tc.req,
 			)
 			if err != nil {
 				t.Fatalf("failed to create test SQL admin service: %s", err)
@@ -232,7 +230,7 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 	}{
 		{
 			req:     mock.InstanceGetSuccess(inst, 1), // not an ephemeral cert call
-			wantErr: "create failed",
+			wantErr: "fetch ephemeral cert failed",
 			desc:    "When the CreateEphemeralCert call fails",
 		},
 	}

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -15,77 +15,334 @@
 package cloudsql
 
 import (
+	"bytes"
 	"context"
-	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/cloudsqlconn/internal/mock"
 	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
-func TestFetchMetadata(t *testing.T) {
-	ctx := context.Background()
-
-	// define some test instance settings
-	cn, err := parseConnName("my-proj:my-region:my-inst")
-	if err != nil {
-		t.Fatalf("%s", err)
+func errorContains(err error, want string) bool {
+	if err == nil {
+		return false
 	}
-	inst := mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name)
-
-	// mock expected requests
-	mc, url, cleanup := mock.HTTPClient(
-		mock.InstanceGetSuccess(inst, 1),
-	)
-	defer func() {
-		if err := cleanup(); err != nil {
-			t.Fatalf("%v", err)
-		}
-	}()
-
-	client, err := sqladmin.NewService(ctx, option.WithHTTPClient(mc), option.WithEndpoint(url))
-	if err != nil {
-		t.Fatalf("client init failed: %s", err)
-	}
-
-	_, err = fetchMetadata(ctx, client, cn)
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
+	return strings.Contains(err.Error(), want)
 }
-func TestFetchEphemeralCert(t *testing.T) {
-	ctx := context.Background()
 
-	// define some test instance settings
-	cn, err := parseConnName("my-proj:my-region:my-inst")
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	inst := mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name)
-
-	// mock expected requests
-	mc, url, cleanup := mock.HTTPClient(
+func TestRefresh(t *testing.T) {
+	wantPublicIP := "127.0.0.1"
+	wantPrivateIP := "10.0.0.1"
+	wantExpiry := time.Now().Add(time.Hour).UTC().Round(time.Second)
+	wantConnName := "my-project:my-region:my-instance"
+	cn, err := parseConnName(wantConnName)
+	inst := mock.NewFakeCSQLInstance(
+		"my-project", "my-region", "my-instance",
+		mock.WithPublicIP(wantPublicIP),
+		mock.WithPrivateIP(wantPrivateIP),
+		mock.WithCertExpiry(wantExpiry),
+	)
+	client, cleanup, err := mock.NewSQLAdminService(
+		context.Background(),
+		mock.InstanceGetSuccess(inst, 1),
 		mock.CreateEphemeralSuccess(inst, 1),
 	)
+	if err != nil {
+		t.Fatalf("failed to create test SQL admin service: %s", err)
+	}
 	defer func() {
 		if err := cleanup(); err != nil {
 			t.Fatalf("%v", err)
 		}
 	}()
 
-	client, err := sqladmin.NewService(ctx, option.WithHTTPClient(mc), option.WithEndpoint(url))
+	r := newRefresher(time.Hour, 30*time.Second, 2, client)
+	md, tlsCfg, gotExpiry, err := r.performRefresh(context.Background(), cn, RSAKey)
 	if err != nil {
-		t.Fatalf("client init failed: %s", err)
-	}
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("failed to generate keys: %v", err)
+		t.Fatalf("PerformRefresh unexpectedly failed with error: %v", err)
 	}
 
-	_, err = fetchEphemeralCert(ctx, client, cn, key)
+	gotIP, ok := md.ipAddrs[PublicIP]
+	if !ok {
+		t.Fatalf("metadata IP addresses did not include public address")
+	}
+	if wantPublicIP != gotIP {
+		t.Fatalf("metadata IP mismatch, want = %v, got = %v", wantPublicIP, gotIP)
+	}
+	gotIP, ok = md.ipAddrs[PrivateIP]
+	if !ok {
+		t.Fatalf("metadata IP addresses did not include private address")
+	}
+	if wantPrivateIP != gotIP {
+		t.Fatalf("metadata IP mismatch, want = %v, got = %v", wantPrivateIP, gotIP)
+	}
+	if wantExpiry != gotExpiry {
+		t.Fatalf("expiry mismatch, want = %v, got = %v", wantExpiry, gotExpiry)
+	}
+	if wantConnName != tlsCfg.ServerName {
+		t.Fatalf("server name mismatch, want = %v, got = %v", wantConnName, tlsCfg.ServerName)
+	}
+}
+
+func TestRefreshFailsFast(t *testing.T) {
+	cn, _ := parseConnName("my-project:my-region:my-instance")
+	inst := mock.NewFakeCSQLInstance("my-project", "my-region", "my-instance")
+	client, cleanup, err := mock.NewSQLAdminService(
+		context.Background(),
+		mock.InstanceGetSuccess(inst, 1),
+		mock.CreateEphemeralSuccess(inst, 1),
+	)
 	if err != nil {
-		t.Fatalf("failed to fetch ephemeral cert: %v", err)
+		t.Fatalf("failed to create test SQL admin service: %s", err)
+	}
+	defer cleanup()
+
+	r := newRefresher(time.Hour, 30*time.Second, 1, client)
+	_, _, _, err = r.performRefresh(context.Background(), cn, RSAKey)
+	if err != nil {
+		t.Fatalf("expected no error, got = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// context is canceled
+	_, _, _, err = r.performRefresh(ctx, cn, RSAKey)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled error, got = %v", err)
+	}
+
+	// force the rate limiter to throttle with a timed out context
+	ctx, _ = context.WithTimeout(context.Background(), time.Millisecond)
+	_, _, _, err = r.performRefresh(ctx, cn, RSAKey)
+
+	if !errorContains(err, "throttled") {
+		t.Fatalf("expected throttled error, got = %v", err)
+	}
+}
+
+func TestRefreshWithFailedMetadataCall(t *testing.T) {
+	cn, _ := parseConnName("my-project:my-region:my-instance")
+
+	testCases := []struct {
+		req     *mock.Request
+		wantErr string
+		desc    string
+	}{
+		{
+			req: mock.CreateEphemeralSuccess(
+				mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name), 1),
+			wantErr: "failed to get instance",
+			desc:    "When the Metadata call fails",
+		},
+		{
+			req: mock.InstanceGetSuccess(
+				mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name,
+					mock.WithRegion("some-other-region")), 1),
+			wantErr: "region was mismatched",
+			desc:    "When the region does not match",
+		},
+		{
+			req: mock.InstanceGetSuccess(
+				mock.NewFakeCSQLInstance(
+					cn.project, cn.region, cn.name,
+					mock.WithRegion("my-region"),
+					mock.WithFirstGenBackend(),
+				), 1),
+			wantErr: "only Second Generation",
+			desc:    "When the instance isn't Second generation",
+		},
+		{
+			req: mock.InstanceGetSuccess(
+				mock.NewFakeCSQLInstance(
+					cn.project, cn.region, cn.name,
+					mock.WithRegion("my-region"),
+					mock.WithMissingIPAddrs(),
+				), 1),
+			wantErr: "no supported IP addresses",
+			desc:    "When the instance has no supported IP addresses",
+		},
+		{
+			req: mock.InstanceGetSuccess(
+				mock.NewFakeCSQLInstance(
+					cn.project, cn.region, cn.name,
+					mock.WithRegion("my-region"),
+					mock.WithSigner(func(_ *x509.Certificate, _ *rsa.PrivateKey) ([]byte, error) {
+						return nil, nil
+					}),
+				), 1),
+			wantErr: "failed to decode",
+			desc:    "When the server cert does not decode",
+		},
+		{
+			req: mock.InstanceGetSuccess(
+				mock.NewFakeCSQLInstance(
+					cn.project, cn.region, cn.name,
+					mock.WithRegion("my-region"),
+					mock.WithSigner(func(_ *x509.Certificate, _ *rsa.PrivateKey) ([]byte, error) {
+						certPEM := &bytes.Buffer{}
+						pem.Encode(certPEM, &pem.Block{
+							Type:  "CERTIFICATE",
+							Bytes: []byte("hello"), // woops no cert
+						})
+						return certPEM.Bytes(), nil
+					}),
+				), 1),
+			wantErr: "failed to parse",
+			desc:    "When the cert is not a valid X.509 cert",
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			mc, url, cleanup := mock.HTTPClient(tc.req)
+			client, err := sqladmin.NewService(
+				context.Background(),
+				option.WithHTTPClient(mc),
+				option.WithEndpoint(url),
+			)
+			if err != nil {
+				t.Fatalf("failed to create test SQL admin service: %s", err)
+			}
+			defer cleanup()
+
+			r := newRefresher(time.Hour, 30*time.Second, 1, client)
+			_, _, _, err = r.performRefresh(context.Background(), cn, RSAKey)
+
+			if !errorContains(err, tc.wantErr) {
+				t.Errorf("[%v] PerformRefresh failed with unexpected error, want = %v, got = %v", i, tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
+	cn, _ := parseConnName("my-project:my-region:my-instance")
+	inst := mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name)
+
+	testCases := []struct {
+		req     *mock.Request
+		wantErr string
+		desc    string
+	}{
+		{
+			req:     mock.InstanceGetSuccess(inst, 1), // not an ephemeral cert call
+			wantErr: "create failed",
+			desc:    "When the CreateEphemeralCert call fails",
+		},
+	}
+	for i, tc := range testCases {
+		mc, url, cleanup := mock.HTTPClient(mock.InstanceGetSuccess(inst, 1), tc.req)
+		client, err := sqladmin.NewService(
+			context.Background(),
+			option.WithHTTPClient(mc),
+			option.WithEndpoint(url),
+		)
+		if err != nil {
+			t.Fatalf("failed to create test SQL admin service: %s", err)
+		}
+		defer cleanup()
+
+		r := newRefresher(time.Hour, 30*time.Second, 1, client)
+		_, _, _, err = r.performRefresh(context.Background(), cn, RSAKey)
+
+		if !errorContains(err, tc.wantErr) {
+			t.Errorf("[%v] PerformRefresh failed with unexpected error, want = %v, got = %v", i, tc.wantErr, err)
+		}
+	}
+}
+
+func TestRefreshBuildsTLSConfig(t *testing.T) {
+	wantServerName := "my-project:my-region:my-instance"
+	cn, _ := parseConnName(wantServerName)
+	inst := mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name)
+	certBytes, err := mock.SelfSign(inst.Cert, inst.Key)
+	if err != nil {
+		t.Fatalf("failed to sign certificate: %v", err)
+	}
+	mc, url, cleanup := mock.HTTPClient(
+		mock.InstanceGetSuccess(inst, 1), // no server cert
+		mock.CreateEphemeralSuccess(inst, 1),
+	)
+	defer cleanup()
+	client, err := sqladmin.NewService(
+		context.Background(),
+		option.WithHTTPClient(mc),
+		option.WithEndpoint(url),
+	)
+	if err != nil {
+		t.Fatalf("failed to create test SQL admin service: %s", err)
+	}
+
+	r := newRefresher(time.Hour, 30*time.Second, 1, client)
+	_, tlsCfg, _, err := r.performRefresh(context.Background(), cn, RSAKey)
+	if err != nil {
+		t.Fatalf("expected no error, got = %v", err)
+	}
+
+	if wantServerName != tlsCfg.ServerName {
+		t.Fatalf(
+			"TLS config has incorrect server name, want = %v, got = %v",
+			wantServerName, tlsCfg.ServerName,
+		)
+	}
+
+	wantCertLen := 1
+	if wantCertLen != len(tlsCfg.Certificates) {
+		t.Fatalf(
+			"TLS config has unexpected number of certificates, want = %v, got = %v",
+			wantCertLen, len(tlsCfg.Certificates),
+		)
+	}
+
+	wantInsecure := true
+	if wantInsecure != tlsCfg.InsecureSkipVerify {
+		t.Fatalf(
+			"TLS config should skip verification, want = %v, got = %v",
+			wantInsecure, tlsCfg.InsecureSkipVerify,
+		)
+	}
+
+	if tlsCfg.RootCAs == nil {
+		t.Fatal("TLS config should include RootCA, got nil")
+	}
+
+	verifyPeerCert := tlsCfg.VerifyPeerCertificate
+	b, _ := pem.Decode(certBytes)
+	err = verifyPeerCert([][]byte{b.Bytes}, nil)
+	if err != nil {
+		t.Fatalf("expected to verify peer cert, got error: %v", err)
+	}
+
+	err = verifyPeerCert(nil, nil)
+	if !errorContains(err, "no certificate") {
+		t.Fatalf("expected verify peer cert to fail, got = %v", err)
+	}
+
+	err = verifyPeerCert([][]byte{[]byte("not a cert")}, nil)
+	if !errorContains(err, "x509.ParseCertificate(rawCerts[0])") {
+		t.Fatalf("expected verify peer cert to fail on invalid cert, got = %v", err)
+	}
+
+	badCert := mock.GenerateCertWithCommonName(inst, "wrong:wrong")
+	err = verifyPeerCert([][]byte{badCert}, nil)
+	if !errorContains(err, "certificate had CN") {
+		t.Fatalf("expected common name mistmatch to error, got = %v", err)
+	}
+
+	other := mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name)
+	certBytes, err = mock.SelfSign(other.Cert, other.Key)
+	if err != nil {
+		t.Fatalf("failed to sign certificate: %v", err)
+	}
+	b, _ = pem.Decode(certBytes)
+	err = verifyPeerCert([][]byte{b.Bytes}, nil)
+	if !errorContains(err, "signed by unknown authority") {
+		t.Fatalf("expected certificate verification to fail, got = %v", err)
 	}
 }

--- a/internal/mock/cloudsql.go
+++ b/internal/mock/cloudsql.go
@@ -114,9 +114,9 @@ func WithCertSigner(s SignFunc) FakeCSQLInstanceOption {
 	}
 }
 
-// ClientSignFunc is a function that produces a certificate signed by the
+// ClientSignFunc is a function that produces a certificate signed using the
 // provided certificate, using the server's private key and the client's public
-// key. The result shoudl be PEM-encoded.
+// key. The result should be PEM-encoded.
 type ClientSignFunc = func(*x509.Certificate, *rsa.PrivateKey, *rsa.PublicKey) ([]byte, error)
 
 // WithClientCertSigner configures the signing function used to generated a

--- a/internal/mock/cloudsql.go
+++ b/internal/mock/cloudsql.go
@@ -50,13 +50,13 @@ type FakeCSQLInstance struct {
 	// ipAddrs is a map of IP type (PUBLIC or PRIVATE) to IP address.
 	ipAddrs     map[string]string
 	backendType string
-	sign        SignFunc
+	signer      SignFunc
 	Key         *rsa.PrivateKey
 	Cert        *x509.Certificate
 }
 
 func (f FakeCSQLInstance) signedCert() ([]byte, error) {
-	return f.sign(f.Cert, f.Key)
+	return f.signer(f.Cert, f.Key)
 }
 
 // FakeCSQLInstanceOption is a function that configures a FakeCSQLInstance.
@@ -101,11 +101,11 @@ func WithFirstGenBackend() FakeCSQLInstanceOption {
 // result should be PEM-encoded.
 type SignFunc = func(*x509.Certificate, *rsa.PrivateKey) ([]byte, error)
 
-// WithSigner configures the signing function used to generate a signed
+// WithCertSigner configures the signing function used to generate a signed
 // certificate.
-func WithSigner(s SignFunc) FakeCSQLInstanceOption {
+func WithCertSigner(s SignFunc) FakeCSQLInstanceOption {
 	return func(f *FakeCSQLInstance) {
-		f.sign = s
+		f.signer = s
 	}
 }
 
@@ -132,7 +132,7 @@ func NewFakeCSQLInstance(project, region, name string, opts ...FakeCSQLInstanceO
 		ipAddrs:     map[string]string{"PUBLIC": "0.0.0.0"},
 		dbVersion:   "POSTGRES_12", // default of no particular importance
 		backendType: "SECOND_GEN",
-		sign:        SelfSign,
+		signer:      SelfSign,
 		Key:         key,
 		Cert:        cert,
 	}

--- a/internal/mock/sqladmin.go
+++ b/internal/mock/sqladmin.go
@@ -31,12 +31,12 @@ import (
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
-// HTTPClient returns an *http.Client, URL, and cleanup function. The http.Client is
+// httpClient returns an *http.Client, URL, and cleanup function. The http.Client is
 // configured to connect to test SSL Server at the returned URL. This server will
 // respond to HTTP requests defined, or return a 5xx server error for unexpected ones.
 // The cleanup function will close the server, and return an error if any expected calls
 // weren't received.
-func HTTPClient(requests ...*Request) (*http.Client, string, func() error) {
+func httpClient(requests ...*Request) (*http.Client, string, func() error) {
 	// Create a TLS Server that responses to the requests defined
 	s := httptest.NewTLSServer(http.HandlerFunc(
 		func(resp http.ResponseWriter, req *http.Request) {
@@ -211,7 +211,7 @@ func CreateEphemeralSuccess(i FakeCSQLInstance, ct int) *Request {
 // the cleanup function returns an error, a caller has not exercised all the
 // registered requests.
 func NewSQLAdminService(ctx context.Context, reqs ...*Request) (*sqladmin.Service, func() error, error) {
-	mc, url, cleanup := HTTPClient(reqs...)
+	mc, url, cleanup := httpClient(reqs...)
 	client, err := sqladmin.NewService(
 		ctx,
 		option.WithHTTPClient(mc),

--- a/internal/mock/sqladmin.go
+++ b/internal/mock/sqladmin.go
@@ -182,7 +182,7 @@ func CreateEphemeralSuccess(i FakeCSQLInstance, ct int) *Request {
 
 			certBytes, err := i.clientCert(pubKey.(*rsa.PublicKey))
 			if err != nil {
-				http.Error(resp, fmt.Errorf("failed to sign instance's certificate: %v", err).Error(), http.StatusBadRequest)
+				http.Error(resp, fmt.Errorf("failed to sign client certificate: %v", err).Error(), http.StatusBadRequest)
 				return
 			}
 


### PR DESCRIPTION
- Introduce an initializer for refresher
- Add functional options to configure a FakeCSQLInstance:
    - WithPrivateIP
    - WithCertExpiry
    - WithRegion
    - WithFirstGenBackend
    - WithSigner
    - WithMissingIPAddrs

Fixes #9.