### PR TITLE
feat: add concrete errors to public API

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -154,23 +154,26 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 	if err != nil {
 		// refresh the instance info in case it caused the connection failure
 		i.ForceRefresh()
-		return nil, &errtypes.DialError{ConnName: i.String(),
-			Message: "failed to dial", Err: err}
+		return nil, errtypes.NewDialError(
+			"failed to dial",
+			i.String(),
+			err,
+		)
 	}
 	if c, ok := conn.(*net.TCPConn); ok {
 		if err := c.SetKeepAlive(true); err != nil {
-			return nil, &errtypes.DialError{
-				ConnName: i.String(),
-				Message:  "failed to set keep-alive",
-				Err:      err,
-			}
+			return nil, errtypes.NewDialError(
+				"failed to set keep-alive",
+				i.String(),
+				err,
+			)
 		}
 		if err := c.SetKeepAlivePeriod(cfg.tcpKeepAlive); err != nil {
-			return nil, &errtypes.DialError{
-				ConnName: i.String(),
-				Message:  "failed to set keep-alive period",
-				Err:      err,
-			}
+			return nil, errtypes.NewDialError(
+				"failed to set keep-alive period",
+				i.String(),
+				err,
+			)
 		}
 	}
 	tlsConn := tls.Client(conn, tlsCfg)
@@ -178,11 +181,11 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		// refresh the instance info in case it caused the handshake failure
 		i.ForceRefresh()
 		_ = tlsConn.Close() // best effort close attempt
-		return nil, &errtypes.DialError{
-			ConnName: i.String(),
-			Message:  "handshake failed",
-			Err:      err,
-		}
+		return nil, errtypes.NewDialError(
+			"handshake failed",
+			i.String(),
+			err,
+		)
 	}
 	return tlsConn, nil
 }

--- a/dialer.go
+++ b/dialer.go
@@ -154,26 +154,14 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 	if err != nil {
 		// refresh the instance info in case it caused the connection failure
 		i.ForceRefresh()
-		return nil, errtypes.NewDialError(
-			"failed to dial",
-			i.String(),
-			err,
-		)
+		return nil, errtypes.NewDialError("failed to dial", i.String(), err)
 	}
 	if c, ok := conn.(*net.TCPConn); ok {
 		if err := c.SetKeepAlive(true); err != nil {
-			return nil, errtypes.NewDialError(
-				"failed to set keep-alive",
-				i.String(),
-				err,
-			)
+			return nil, errtypes.NewDialError("failed to set keep-alive", i.String(), err)
 		}
 		if err := c.SetKeepAlivePeriod(cfg.tcpKeepAlive); err != nil {
-			return nil, errtypes.NewDialError(
-				"failed to set keep-alive period",
-				i.String(),
-				err,
-			)
+			return nil, errtypes.NewDialError("failed to set keep-alive period", i.String(), err)
 		}
 	}
 	tlsConn := tls.Client(conn, tlsCfg)
@@ -181,11 +169,7 @@ func (d *Dialer) Dial(ctx context.Context, instance string, opts ...DialOption) 
 		// refresh the instance info in case it caused the handshake failure
 		i.ForceRefresh()
 		_ = tlsConn.Close() // best effort close attempt
-		return nil, errtypes.NewDialError(
-			"handshake failed",
-			i.String(),
-			err,
-		)
+		return nil, errtypes.NewDialError("handshake failed", i.String(), err)
 	}
 	return tlsConn, nil
 }

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -106,7 +106,7 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 	}
 
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	var wantErr2 *errtypes.ServerError
+	var wantErr2 *errtypes.RefreshError
 	if !errors.As(err, &wantErr2) {
 		t.Fatalf("when API call fails, want = %T, got = %v", wantErr2, err)
 	}

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -92,7 +92,7 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 	d.sqladmin = svc
 
 	_, err = d.Dial(context.Background(), "bad-instance-name")
-	var wantErr1 *errtypes.ClientError
+	var wantErr1 *errtypes.ConfigError
 	if !errors.As(err, &wantErr1) {
 		t.Fatalf("when instance name is invalid, want = %T, got = %v", wantErr1, err)
 	}
@@ -106,7 +106,7 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 	}
 
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	var wantErr2 *errtypes.APIError
+	var wantErr2 *errtypes.ServerError
 	if !errors.As(err, &wantErr2) {
 		t.Fatalf("when API call fails, want = %T, got = %v", wantErr2, err)
 	}
@@ -135,7 +135,7 @@ func TestDialWithConfigurationErrors(t *testing.T) {
 	}()
 
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance", WithPrivateIP())
-	var wantErr1 *errtypes.ClientError
+	var wantErr1 *errtypes.ConfigError
 	if !errors.As(err, &wantErr1) {
 		t.Fatalf("when IP type is invalid, want = %T, got = %v", wantErr1, err)
 	}

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
-	"strings"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/cloudsqlconn/errtypes"
 	"cloud.google.com/go/cloudsqlconn/internal/mock"
 )
 
@@ -71,13 +71,6 @@ func TestDialerInstantiationErrors(t *testing.T) {
 	}
 }
 
-func errorContains(err error, want string) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), want)
-}
-
 func TestDialWithAdminAPIErrors(t *testing.T) {
 	inst := mock.NewFakeCSQLInstance("my-project", "my-region", "my-instance")
 	svc, cleanup, err := mock.NewSQLAdminService(context.Background())
@@ -98,25 +91,24 @@ func TestDialWithAdminAPIErrors(t *testing.T) {
 	}
 	d.sqladmin = svc
 
-	// instance name is bad
 	_, err = d.Dial(context.Background(), "bad-instance-name")
-	if !errorContains(err, "invalid instance") {
-		t.Fatalf("expected Dial to fail with bad instance name, but it succeeded.")
+	var wantErr1 *errtypes.ClientError
+	if !errors.As(err, &wantErr1) {
+		t.Fatalf("when instance name is invalid, want = %T, got = %v", wantErr1, err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	// context is canceled
 	_, err = d.Dial(ctx, "my-project:my-region:my-instance")
 	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected Dial to fail with canceled context, but it succeeded.")
+		t.Fatalf("when context is canceled, want = %T, got = %v", context.Canceled, err)
 	}
 
-	// failed to retrieve metadata or ephemeral cert (not registered in the mock)
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	if !errorContains(err, "fetch metadata failed") {
-		t.Fatalf("expected Dial to fail with missing metadata")
+	var wantErr2 *errtypes.APIError
+	if !errors.As(err, &wantErr2) {
+		t.Fatalf("when API call fails, want = %T, got = %v", wantErr2, err)
 	}
 }
 
@@ -142,24 +134,23 @@ func TestDialWithConfigurationErrors(t *testing.T) {
 		}
 	}()
 
-	// when failing to find private IP for public-only instance
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance", WithPrivateIP())
-	if !errorContains(err, "does not have IP of type") {
-		t.Fatalf("expected Dial to fail with missing metadata")
+	var wantErr1 *errtypes.ClientError
+	if !errors.As(err, &wantErr1) {
+		t.Fatalf("when IP type is invalid, want = %T, got = %v", wantErr1, err)
 	}
 
-	// when Dialing TCP socket fails (no server proxy running)
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	if !errorContains(err, "connection refused") {
-		t.Fatalf("expected Dial to fail with connection error")
+	var wantErr2 *errtypes.DialError
+	if !errors.As(err, &wantErr2) {
+		t.Fatalf("when server proxy socket is unavailable, want = %T, got = %v", wantErr2, err)
 	}
 
 	stop := mock.StartServerProxy(t, inst)
 	defer stop()
 
-	// when TLS handshake fails
 	_, err = d.Dial(context.Background(), "my-project:my-region:my-instance")
-	if !errorContains(err, "handshake failed") {
-		t.Fatalf("expected Dial to fail with connection error")
+	if !errors.As(err, &wantErr2) {
+		t.Fatalf("when TLS handshake fails, want = %T, got = %v", wantErr2, err)
 	}
 }

--- a/errtypes/doc.go
+++ b/errtypes/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2021 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package errtypes provides a number of concrete types which are used by the
+// cloudsqlconn package.
+package errtypes // import "cloud.google.com/go/cloudsqlconn/errtypes"

--- a/errtypes/errors.go
+++ b/errtypes/errors.go
@@ -47,9 +47,9 @@ func NewRefreshError(msg, cn string, err error) *RefreshError {
 
 // RefreshError means that an error occurred during the background
 // refresh operation. In general, this is an unexpected error caused by
-// an interaction with the API itself. (e.g., missing certificates, 
-// invalid certificate encoding, region mismatch with the requested 
-// instance connection name, etc.)
+// an interaction with the API itself (e.g., missing certificates,
+// invalid certificate encoding, region mismatch with the requested
+// instance connection name, etc.).
 type RefreshError struct {
 	*genericError
 	// Err is the underlying error and may be nil.

--- a/errtypes/errors.go
+++ b/errtypes/errors.go
@@ -37,33 +37,33 @@ func NewConfigError(msg, cn string) *ConfigError {
 // malformated, the SQL instance does not support the requested IP type, etc.)
 type ConfigError struct{ *genericError }
 
-// NewServerError initializes a ServerError.
-func NewServerError(msg, cn string, err error) *ServerError {
-	return &ServerError{
+// NewRefreshError initializes a RefreshError.
+func NewRefreshError(msg, cn string, err error) *RefreshError {
+	return &RefreshError{
 		genericError: &genericError{Message: msg, ConnName: cn},
 		Err:          err,
 	}
 }
 
-// ServerError means the server returned with unexpected or invalid data. In
+// RefreshError means the server returned with unexpected or invalid data. In
 // general, this is an unexpected error and if a caller receives the error,
 // there is likely a problem with the backend API or the instance itself (e.g.,
 // missing certificates, invalid certificate encoding, region mismatch with the
 // requested instance connection name, etc.)
-type ServerError struct {
+type RefreshError struct {
 	*genericError
 	// Err is the underlying error and may be nil.
 	Err error
 }
 
-func (e *ServerError) Error() string {
+func (e *RefreshError) Error() string {
 	if e.Err == nil {
 		return fmt.Sprintf("Server error: %v", e.genericError)
 	}
 	return fmt.Sprintf("Server error: %v: %v", e.genericError, e.Err)
 }
 
-func (e *ServerError) Unwrap() error { return e.Err }
+func (e *RefreshError) Unwrap() error { return e.Err }
 
 // NewDialError initializes a DialError.
 func NewDialError(msg, cn string, err error) *DialError {
@@ -78,6 +78,7 @@ func NewDialError(msg, cn string, err error) *DialError {
 // failure, a missing certificate, etc.)
 type DialError struct {
 	*genericError
+	// Err is the underlying error and may be nil.
 	Err error
 }
 

--- a/errtypes/errors.go
+++ b/errtypes/errors.go
@@ -45,11 +45,11 @@ func NewRefreshError(msg, cn string, err error) *RefreshError {
 	}
 }
 
-// RefreshError means the server returned with unexpected or invalid data. In
-// general, this is an unexpected error and if a caller receives the error,
-// there is likely a problem with the backend API or the instance itself (e.g.,
-// missing certificates, invalid certificate encoding, region mismatch with the
-// requested instance connection name, etc.)
+// RefreshError means that an error occurred during the background
+// refresh operation. In general, this is an unexpected error caused by
+// an interaction with the API itself. (e.g., missing certificates, 
+// invalid certificate encoding, region mismatch with the requested 
+// instance connection name, etc.)
 type RefreshError struct {
 	*genericError
 	// Err is the underlying error and may be nil.

--- a/errtypes/errors.go
+++ b/errtypes/errors.go
@@ -1,0 +1,91 @@
+// Copyright 2021 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errtypes
+
+import "fmt"
+
+type genericError struct {
+	Message  string
+	ConnName string
+}
+
+func (e *genericError) Error() string {
+	return fmt.Sprintf("%v (connection name = %q)", e.Message, e.ConnName)
+}
+
+// NewClientError initializes a ClientError.
+func NewClientError(msg, cn string) *ClientError {
+	return &ClientError{
+		genericError: &genericError{Message: "Client error: " + msg, ConnName: cn},
+	}
+}
+
+// ClientError represents an incorrect request by the client. Client errors
+// usually indicate a semantic error (e.g., the instance connection name is
+// malformated, the SQL instance does not support the requested IP type, etc.)
+type ClientError struct{ *genericError }
+
+// NewServerError initializes a ServerError.
+func NewServerError(msg, cn string) *ServerError {
+	return &ServerError{
+		genericError: &genericError{Message: "Server error: " + msg, ConnName: cn},
+	}
+}
+
+// ServerError means the server returned with unexpected or invalid data. In
+// general, this is an unexpected error and if a caller receives the error,
+// there is likely a problem with the backend API or the instance itself (e.g.,
+// missing certificates, invalid certificate encoding, region mismatch with the
+// requested instance connection name, etc.)
+type ServerError struct{ *genericError }
+
+// APIError represents an error with the underlying network call to the SQL
+// Admin API. APIErrors typically wrap Error types from the
+// google.golang.org/api/googleapi package.
+type APIError struct {
+	Op       string
+	ConnName string
+	Message  string
+	Err      error
+}
+
+func (e *APIError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("API error: Operation %s failed (connection name = %q): %v",
+			e.Op, e.ConnName, e.Err)
+	}
+	return fmt.Sprintf("API error: Operation %s failed (connection name = %q)",
+		e.Op, e.ConnName)
+}
+
+func (e *APIError) Unwrap() error { return e.Err }
+
+// DialError represents a problem that occurred when trying to dial a SQL
+// instance (e.g., a failure to set the keep-alive property, a TLS handshake
+// failure, a missing certificate, etc.)
+type DialError struct {
+	ConnName string
+	Message  string
+	Err      error
+}
+
+func (e *DialError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("Dial error: %v (connection name = %q)", e.Message, e.ConnName)
+	}
+	return fmt.Sprintf("Dial error: %v (connection name = %q): %v", e.Message, e.ConnName, e.Err)
+}
+
+func (e *DialError) Unwrap() error { return e.Err }

--- a/errtypes/errors_test.go
+++ b/errtypes/errors_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errtypes_test
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/cloudsqlconn/errtypes"
+)
+
+func TestErrorFormatting(t *testing.T) {
+	tc := []struct {
+		desc string
+		err  error
+		want string
+	}{
+		{
+			desc: "client error message",
+			err:  errtypes.NewClientError("error message", "proj:reg:inst"),
+			want: "Client error: error message (connection name = \"proj:reg:inst\")",
+		},
+		{
+			desc: "server error message",
+			err:  errtypes.NewServerError("error message", "proj:reg:inst"),
+			want: "Server error: error message (connection name = \"proj:reg:inst\")",
+		},
+		{
+			desc: "API error without inner error",
+			err: &errtypes.APIError{
+				Op:       "Do.Something",
+				ConnName: "proj:reg:inst",
+				Message:  "message",
+				Err:      nil, // no error here
+			},
+			want: "API error: Operation Do.Something failed (connection name = \"proj:reg:inst\")",
+		},
+		{
+			desc: "API error with inner error",
+			err: &errtypes.APIError{
+				Op:       "Do.Something",
+				ConnName: "proj:reg:inst",
+				Message:  "message",
+				Err:      errors.New("inner-error"),
+			},
+			want: "API error: Operation Do.Something failed (connection name = \"proj:reg:inst\"): inner-error",
+		},
+		{
+			desc: "Dial error without inner error",
+			err: &errtypes.DialError{
+				ConnName: "proj:reg:inst",
+				Message:  "message",
+				Err:      nil, // no error here
+			},
+			want: "Dial error: message (connection name = \"proj:reg:inst\")",
+		},
+		{
+			desc: "Dial error with inner error",
+			err: &errtypes.DialError{
+				ConnName: "proj:reg:inst",
+				Message:  "message",
+				Err:      errors.New("inner-error"),
+			},
+			want: "Dial error: message (connection name = \"proj:reg:inst\"): inner-error",
+		},
+	}
+
+	for _, c := range tc {
+		if got := c.err.Error(); got != c.want {
+			t.Errorf("%v, got = %q, want = %q", c.desc, got, c.want)
+		}
+	}
+}

--- a/errtypes/errors_test.go
+++ b/errtypes/errors_test.go
@@ -29,50 +29,35 @@ func TestErrorFormatting(t *testing.T) {
 	}{
 		{
 			desc: "client error message",
-			err:  errtypes.NewClientError("error message", "proj:reg:inst"),
+			err:  errtypes.NewConfigError("error message", "proj:reg:inst"),
 			want: "Client error: error message (connection name = \"proj:reg:inst\")",
 		},
 		{
-			desc: "server error message",
-			err:  errtypes.NewServerError("error message", "proj:reg:inst"),
+			desc: "server error message without internal error",
+			err:  errtypes.NewServerError("error message", "proj:reg:inst", nil),
 			want: "Server error: error message (connection name = \"proj:reg:inst\")",
 		},
 		{
-			desc: "API error without inner error",
-			err: &errtypes.APIError{
-				Op:       "Do.Something",
-				ConnName: "proj:reg:inst",
-				Message:  "message",
-				Err:      nil, // no error here
-			},
-			want: "API error: Operation Do.Something failed (connection name = \"proj:reg:inst\")",
-		},
-		{
-			desc: "API error with inner error",
-			err: &errtypes.APIError{
-				Op:       "Do.Something",
-				ConnName: "proj:reg:inst",
-				Message:  "message",
-				Err:      errors.New("inner-error"),
-			},
-			want: "API error: Operation Do.Something failed (connection name = \"proj:reg:inst\"): inner-error",
+			desc: "server error message with internal error",
+			err:  errtypes.NewServerError("error message", "proj:reg:inst", errors.New("inner-error")),
+			want: "Server error: error message (connection name = \"proj:reg:inst\"): inner-error",
 		},
 		{
 			desc: "Dial error without inner error",
-			err: &errtypes.DialError{
-				ConnName: "proj:reg:inst",
-				Message:  "message",
-				Err:      nil, // no error here
-			},
+			err: errtypes.NewDialError(
+				"message",
+				"proj:reg:inst",
+				nil, // no error here
+			),
 			want: "Dial error: message (connection name = \"proj:reg:inst\")",
 		},
 		{
 			desc: "Dial error with inner error",
-			err: &errtypes.DialError{
-				ConnName: "proj:reg:inst",
-				Message:  "message",
-				Err:      errors.New("inner-error"),
-			},
+			err: errtypes.NewDialError(
+				"message",
+				"proj:reg:inst",
+				errors.New("inner-error"),
+			),
 			want: "Dial error: message (connection name = \"proj:reg:inst\"): inner-error",
 		},
 	}

--- a/errtypes/errors_test.go
+++ b/errtypes/errors_test.go
@@ -34,12 +34,12 @@ func TestErrorFormatting(t *testing.T) {
 		},
 		{
 			desc: "server error message without internal error",
-			err:  errtypes.NewServerError("error message", "proj:reg:inst", nil),
+			err:  errtypes.NewRefreshError("error message", "proj:reg:inst", nil),
 			want: "Server error: error message (connection name = \"proj:reg:inst\")",
 		},
 		{
 			desc: "server error message with internal error",
-			err:  errtypes.NewServerError("error message", "proj:reg:inst", errors.New("inner-error")),
+			err:  errtypes.NewRefreshError("error message", "proj:reg:inst", errors.New("inner-error")),
 			want: "Server error: error message (connection name = \"proj:reg:inst\"): inner-error",
 		},
 		{

--- a/internal/cloudsql/instance.go
+++ b/internal/cloudsql/instance.go
@@ -55,7 +55,7 @@ func parseConnName(cn string) (connName, error) {
 	b := []byte(cn)
 	m := connNameRegex.FindSubmatch(b)
 	if m == nil {
-		err := errtypes.NewClientError(
+		err := errtypes.NewConfigError(
 			"invalid instance connection name, expected PROJECT:REGION:INSTANCE",
 			cn,
 		)
@@ -183,7 +183,7 @@ func (i *Instance) ConnectInfo(ctx context.Context, ipType string) (string, *tls
 	}
 	addr, ok := res.md.ipAddrs[ipType]
 	if !ok {
-		err := errtypes.NewClientError(
+		err := errtypes.NewConfigError(
 			fmt.Sprintf("instance does not have IP of type %q", ipType),
 			i.String(),
 		)

--- a/internal/cloudsql/instance_test.go
+++ b/internal/cloudsql/instance_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/cloudsqlconn/errtypes"
 	"cloud.google.com/go/cloudsqlconn/internal/mock"
 )
 
@@ -127,8 +128,9 @@ func TestConnectInfoErrors(t *testing.T) {
 	}
 
 	_, _, err = im.ConnectInfo(ctx, PublicIP)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("failed to retrieve connect info: %v", err)
+	var wantErr *errtypes.DialError
+	if !errors.As(err, &wantErr) {
+		t.Fatalf("when connect info fails, want = %T, got = %v", wantErr, err)
 	}
 
 	// when client asks for wrong IP address type

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -49,19 +49,18 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst connName)
 	defer func() { end(err) }()
 	db, err := client.Instances.Get(inst.project, inst.name).Context(ctx).Do()
 	if err != nil {
-		return metadata{}, &errtypes.APIError{
-			Op: "Instances.Get", ConnName: inst.String(), Err: err}
+		return metadata{}, errtypes.NewServerError("failed to get instance metadata", inst.String(), err)
 	}
-
 	// validate the instance is supported for authenticated connections
 	if db.Region != inst.region {
 		return metadata{}, errtypes.NewServerError(
 			fmt.Sprintf("provided region was mismatched - got %s, want %s", inst.region, db.Region),
 			inst.String(),
+			nil,
 		)
 	}
 	if db.BackendType != "SECOND_GEN" {
-		return metadata{}, errtypes.NewClientError(
+		return metadata{}, errtypes.NewConfigError(
 			"unsupported instance - only Second Generation instances are supported",
 			inst.String(),
 		)
@@ -78,7 +77,7 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst connName)
 		}
 	}
 	if len(ipAddrs) == 0 {
-		return metadata{}, errtypes.NewClientError(
+		return metadata{}, errtypes.NewConfigError(
 			"cannot connect to instance - it has no supported IP addresses",
 			inst.String(),
 		)
@@ -90,6 +89,7 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst connName)
 		return metadata{}, errtypes.NewServerError(
 			"failed to decode valid PEM cert",
 			inst.String(),
+			nil,
 		)
 	}
 	cert, err := x509.ParseCertificate(b.Bytes)
@@ -97,6 +97,7 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst connName)
 		return metadata{}, errtypes.NewServerError(
 			fmt.Sprintf("failed to parse as X.509 certificate: %v", err),
 			inst.String(),
+			nil,
 		)
 	}
 
@@ -126,12 +127,11 @@ func fetchEphemeralCert(ctx context.Context, client *sqladmin.Service, inst conn
 	}
 	resp, err := client.SslCerts.CreateEphemeral(inst.project, inst.name, &req).Context(ctx).Do()
 	if err != nil {
-		return tls.Certificate{}, &errtypes.APIError{
-			Op:       "SslCerts.CreateEphemeral",
-			ConnName: inst.String(),
-			Message:  "create ephemeral cert failed",
-			Err:      err,
-		}
+		return tls.Certificate{}, errtypes.NewServerError(
+			"create ephemeral cert failed",
+			inst.String(),
+			err,
+		)
 	}
 
 	// parse the client cert
@@ -140,6 +140,7 @@ func fetchEphemeralCert(ctx context.Context, client *sqladmin.Service, inst conn
 		return tls.Certificate{}, errtypes.NewServerError(
 			"failed to decode valid PEM cert",
 			inst.String(),
+			nil,
 		)
 	}
 	clientCert, err := x509.ParseCertificate(b.Bytes)
@@ -147,6 +148,7 @@ func fetchEphemeralCert(ctx context.Context, client *sqladmin.Service, inst conn
 		return tls.Certificate{}, errtypes.NewServerError(
 			fmt.Sprintf("failed to parse as X.509 certificate: %v", err),
 			inst.String(),
+			nil,
 		)
 	}
 
@@ -187,27 +189,39 @@ func createTLSConfig(inst connName, m metadata, cert tls.Certificate) *tls.Confi
 func genVerifyPeerCertificateFunc(cn connName, pool *x509.CertPool) func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if len(rawCerts) == 0 {
-			return &errtypes.DialError{ConnName: cn.String(),
-				Message: "no certificate to verify"}
+			return errtypes.NewDialError(
+				"no certificate to verify",
+				cn.String(),
+				nil,
+			)
 		}
 
 		cert, err := x509.ParseCertificate(rawCerts[0])
 		if err != nil {
-			return &errtypes.DialError{ConnName: cn.String(),
-				Message: "failed to parse X.509 certificate", Err: err}
+			return errtypes.NewDialError(
+				"failed to parse X.509 certificate",
+				cn.String(),
+				err,
+			)
 		}
 
 		opts := x509.VerifyOptions{Roots: pool}
 		if _, err = cert.Verify(opts); err != nil {
-			return &errtypes.DialError{ConnName: cn.String(),
-				Message: "failed to verify certificate", Err: err}
+			return errtypes.NewDialError(
+				"failed to verify certificate",
+				cn.String(),
+				err,
+			)
 		}
 
 		certInstanceName := fmt.Sprintf("%s:%s", cn.project, cn.name)
 		if cert.Subject.CommonName != certInstanceName {
-			return &errtypes.DialError{ConnName: cn.String(),
-				Message: fmt.Sprintf("certificate had CN %q, expected %q",
-					cert.Subject.CommonName, certInstanceName)}
+			return errtypes.NewDialError(
+				fmt.Sprintf("certificate had CN %q, expected %q",
+					cert.Subject.CommonName, certInstanceName),
+				cn.String(),
+				nil,
+			)
 		}
 		return nil
 	}
@@ -248,10 +262,11 @@ func (r refresher) performRefresh(ctx context.Context, cn connName, k *rsa.Priva
 	// avoid refreshing too often to try not to tax the SQL Admin API quotas
 	err = r.clientLimiter.Wait(ctx)
 	if err != nil {
-		return metadata{}, nil, time.Time{}, &errtypes.DialError{
-			ConnName: cn.String(),
-			Message:  "refresh was throttled until context expired",
-		}
+		return metadata{}, nil, time.Time{}, errtypes.NewDialError(
+			"refresh was throttled until context expired",
+			cn.String(),
+			nil,
+		)
 	}
 
 	// start async fetching the instance's metadata

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -53,11 +53,8 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst connName)
 	}
 	// validate the instance is supported for authenticated connections
 	if db.Region != inst.region {
-		return metadata{}, errtypes.NewRefreshError(
-			fmt.Sprintf("provided region was mismatched - got %s, want %s", inst.region, db.Region),
-			inst.String(),
-			nil,
-		)
+		msg := fmt.Sprintf("provided region was mismatched - got %s, want %s", inst.region, db.Region)
+		return metadata{}, errtypes.NewRefreshError(msg, inst.String(), nil)
 	}
 	if db.BackendType != "SECOND_GEN" {
 		return metadata{}, errtypes.NewConfigError(

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -83,11 +83,7 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst connName)
 	// parse the server-side CA certificate
 	b, _ := pem.Decode([]byte(db.ServerCaCert.Cert))
 	if b == nil {
-		return metadata{}, errtypes.NewRefreshError(
-			"failed to decode valid PEM cert",
-			inst.String(),
-			nil,
-		)
+		return metadata{}, errtypes.NewRefreshError("failed to decode valid PEM cert", inst.String(), nil)
 	}
 	cert, err := x509.ParseCertificate(b.Bytes)
 	if err != nil {
@@ -186,29 +182,17 @@ func createTLSConfig(inst connName, m metadata, cert tls.Certificate) *tls.Confi
 func genVerifyPeerCertificateFunc(cn connName, pool *x509.CertPool) func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if len(rawCerts) == 0 {
-			return errtypes.NewDialError(
-				"no certificate to verify",
-				cn.String(),
-				nil,
-			)
+			return errtypes.NewDialError("no certificate to verify", cn.String(), nil)
 		}
 
 		cert, err := x509.ParseCertificate(rawCerts[0])
 		if err != nil {
-			return errtypes.NewDialError(
-				"failed to parse X.509 certificate",
-				cn.String(),
-				err,
-			)
+			return errtypes.NewDialError("failed to parse X.509 certificate", cn.String(), err)
 		}
 
 		opts := x509.VerifyOptions{Roots: pool}
 		if _, err = cert.Verify(opts); err != nil {
-			return errtypes.NewDialError(
-				"failed to verify certificate",
-				cn.String(),
-				err,
-			)
+			return errtypes.NewDialError("failed to verify certificate", cn.String(), err)
 		}
 
 		certInstanceName := fmt.Sprintf("%s:%s", cn.project, cn.name)

--- a/internal/cloudsql/refresh.go
+++ b/internal/cloudsql/refresh.go
@@ -20,10 +20,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"time"
 
+	"cloud.google.com/go/cloudsqlconn/errtypes"
 	"cloud.google.com/go/cloudsqlconn/internal/trace"
 	"golang.org/x/time/rate"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
@@ -49,15 +49,22 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst connName)
 	defer func() { end(err) }()
 	db, err := client.Instances.Get(inst.project, inst.name).Context(ctx).Do()
 	if err != nil {
-		return metadata{}, fmt.Errorf("failed to get instance (%s): %w", inst, err)
+		return metadata{}, &errtypes.APIError{
+			Op: "Instances.Get", ConnName: inst.String(), Err: err}
 	}
 
 	// validate the instance is supported for authenticated connections
 	if db.Region != inst.region {
-		return metadata{}, fmt.Errorf("provided region was mismatched - got %s, want %s", inst.region, db.Region)
+		return metadata{}, errtypes.NewServerError(
+			fmt.Sprintf("provided region was mismatched - got %s, want %s", inst.region, db.Region),
+			inst.String(),
+		)
 	}
 	if db.BackendType != "SECOND_GEN" {
-		return metadata{}, fmt.Errorf("unsupported instance - only Second Generation instances are supported")
+		return metadata{}, errtypes.NewClientError(
+			"unsupported instance - only Second Generation instances are supported",
+			inst.String(),
+		)
 	}
 
 	// parse any ip addresses that might be used to connect
@@ -71,17 +78,26 @@ func fetchMetadata(ctx context.Context, client *sqladmin.Service, inst connName)
 		}
 	}
 	if len(ipAddrs) == 0 {
-		return metadata{}, fmt.Errorf("cannot connect to instance - it has no supported IP addresses")
+		return metadata{}, errtypes.NewClientError(
+			"cannot connect to instance - it has no supported IP addresses",
+			inst.String(),
+		)
 	}
 
 	// parse the server-side CA certificate
 	b, _ := pem.Decode([]byte(db.ServerCaCert.Cert))
 	if b == nil {
-		return metadata{}, errors.New("failed to decode valid PEM cert")
+		return metadata{}, errtypes.NewServerError(
+			"failed to decode valid PEM cert",
+			inst.String(),
+		)
 	}
 	cert, err := x509.ParseCertificate(b.Bytes)
 	if err != nil {
-		return metadata{}, fmt.Errorf("failed to parse as x509 cert: %s", err)
+		return metadata{}, errtypes.NewServerError(
+			fmt.Sprintf("failed to parse as X.509 certificate: %v", err),
+			inst.String(),
+		)
 	}
 
 	m = metadata{
@@ -110,17 +126,28 @@ func fetchEphemeralCert(ctx context.Context, client *sqladmin.Service, inst conn
 	}
 	resp, err := client.SslCerts.CreateEphemeral(inst.project, inst.name, &req).Context(ctx).Do()
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("create ephemeral cert failed: %w", err)
+		return tls.Certificate{}, &errtypes.APIError{
+			Op:       "SslCerts.CreateEphemeral",
+			ConnName: inst.String(),
+			Message:  "create ephemeral cert failed",
+			Err:      err,
+		}
 	}
 
 	// parse the client cert
 	b, _ := pem.Decode([]byte(resp.Cert))
 	if b == nil {
-		return tls.Certificate{}, errors.New("failed to decode valid PEM cert")
+		return tls.Certificate{}, errtypes.NewServerError(
+			"failed to decode valid PEM cert",
+			inst.String(),
+		)
 	}
 	clientCert, err := x509.ParseCertificate(b.Bytes)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("failed to parse as x509 cert: %s", err)
+		return tls.Certificate{}, errtypes.NewServerError(
+			fmt.Sprintf("failed to parse as X.509 certificate: %v", err),
+			inst.String(),
+		)
 	}
 
 	c = tls.Certificate{
@@ -160,22 +187,27 @@ func createTLSConfig(inst connName, m metadata, cert tls.Certificate) *tls.Confi
 func genVerifyPeerCertificateFunc(cn connName, pool *x509.CertPool) func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if len(rawCerts) == 0 {
-			return fmt.Errorf("no certificate to verify")
+			return &errtypes.DialError{ConnName: cn.String(),
+				Message: "no certificate to verify"}
 		}
 
 		cert, err := x509.ParseCertificate(rawCerts[0])
 		if err != nil {
-			return fmt.Errorf("x509.ParseCertificate(rawCerts[0]) returned error: %v", err)
+			return &errtypes.DialError{ConnName: cn.String(),
+				Message: "failed to parse X.509 certificate", Err: err}
 		}
 
 		opts := x509.VerifyOptions{Roots: pool}
 		if _, err = cert.Verify(opts); err != nil {
-			return err
+			return &errtypes.DialError{ConnName: cn.String(),
+				Message: "failed to verify certificate", Err: err}
 		}
 
 		certInstanceName := fmt.Sprintf("%s:%s", cn.project, cn.name)
 		if cert.Subject.CommonName != certInstanceName {
-			return fmt.Errorf("certificate had CN %q, expected %q", cert.Subject.CommonName, certInstanceName)
+			return &errtypes.DialError{ConnName: cn.String(),
+				Message: fmt.Sprintf("certificate had CN %q, expected %q",
+					cert.Subject.CommonName, certInstanceName)}
 		}
 		return nil
 	}
@@ -216,7 +248,10 @@ func (r refresher) performRefresh(ctx context.Context, cn connName, k *rsa.Priva
 	// avoid refreshing too often to try not to tax the SQL Admin API quotas
 	err = r.clientLimiter.Wait(ctx)
 	if err != nil {
-		return metadata{}, nil, time.Time{}, fmt.Errorf("refresh was throttled until context expired: %w", err)
+		return metadata{}, nil, time.Time{}, &errtypes.DialError{
+			ConnName: cn.String(),
+			Message:  "refresh was throttled until context expired",
+		}
 	}
 
 	// start async fetching the instance's metadata
@@ -247,7 +282,7 @@ func (r refresher) performRefresh(ctx context.Context, cn connName, k *rsa.Priva
 	select {
 	case r := <-mdC:
 		if r.err != nil {
-			return md, nil, time.Time{}, fmt.Errorf("fetch metadata failed: %w", r.err)
+			return md, nil, time.Time{}, fmt.Errorf("failed to get instance: %w", r.err)
 		}
 		md = r.md
 	case <-ctx.Done():

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -130,14 +130,14 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 		{
 			req: mock.CreateEphemeralSuccess(
 				mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name), 1),
-			wantErr: &errtypes.ServerError{},
+			wantErr: &errtypes.RefreshError{},
 			desc:    "When the Metadata call fails",
 		},
 		{
 			req: mock.InstanceGetSuccess(
 				mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name,
 					mock.WithRegion("some-other-region")), 1),
-			wantErr: &errtypes.ServerError{},
+			wantErr: &errtypes.RefreshError{},
 			desc:    "When the region does not match",
 		},
 		{
@@ -169,7 +169,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 						return nil, nil
 					}),
 				), 1),
-			wantErr: &errtypes.ServerError{},
+			wantErr: &errtypes.RefreshError{},
 			desc:    "When the server cert does not decode",
 		},
 		{
@@ -186,7 +186,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 						return certPEM.Bytes(), nil
 					}),
 				), 1),
-			wantErr: &errtypes.ServerError{},
+			wantErr: &errtypes.RefreshError{},
 			desc:    "When the cert is not a valid X.509 cert",
 		},
 	}
@@ -222,7 +222,7 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 	}{
 		{
 			reqs:    []*mock.Request{mock.InstanceGetSuccess(inst, 1)}, // no ephemeral cert call registered
-			wantErr: &errtypes.ServerError{},
+			wantErr: &errtypes.RefreshError{},
 			desc:    "When the CreateEphemeralCert call fails",
 		},
 		{
@@ -235,7 +235,7 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 							}),
 					), 1),
 			},
-			wantErr: &errtypes.ServerError{},
+			wantErr: &errtypes.RefreshError{},
 			desc:    "When decoding the cert fails", // SQL Admin API fail
 		},
 		{
@@ -253,7 +253,7 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 							}),
 					), 1),
 			},
-			wantErr: &errtypes.ServerError{},
+			wantErr: &errtypes.RefreshError{},
 			desc:    "When parsing the cert fails", // SQL Admin API fail
 		},
 	}

--- a/internal/cloudsql/refresh_test.go
+++ b/internal/cloudsql/refresh_test.go
@@ -130,7 +130,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 		{
 			req: mock.CreateEphemeralSuccess(
 				mock.NewFakeCSQLInstance(cn.project, cn.region, cn.name), 1),
-			wantErr: &errtypes.APIError{},
+			wantErr: &errtypes.ServerError{},
 			desc:    "When the Metadata call fails",
 		},
 		{
@@ -147,7 +147,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 					mock.WithRegion("my-region"),
 					mock.WithFirstGenBackend(),
 				), 1),
-			wantErr: &errtypes.ClientError{},
+			wantErr: &errtypes.ConfigError{},
 			desc:    "When the instance isn't Second generation",
 		},
 		{
@@ -157,7 +157,7 @@ func TestRefreshWithFailedMetadataCall(t *testing.T) {
 					mock.WithRegion("my-region"),
 					mock.WithMissingIPAddrs(),
 				), 1),
-			wantErr: &errtypes.ClientError{},
+			wantErr: &errtypes.ConfigError{},
 			desc:    "When the instance has no supported IP addresses",
 		},
 		{
@@ -222,7 +222,7 @@ func TestRefreshWithFailedEphemeralCertCall(t *testing.T) {
 	}{
 		{
 			reqs:    []*mock.Request{mock.InstanceGetSuccess(inst, 1)}, // no ephemeral cert call registered
-			wantErr: &errtypes.APIError{},
+			wantErr: &errtypes.ServerError{},
 			desc:    "When the CreateEphemeralCert call fails",
 		},
 		{


### PR DESCRIPTION
This commit adds three concrete errors to the public API and ensures that
all returned errors are either instances of those concrete types OR are
wrapped by more descriptive errors.

The three error types are:

1. ConfigError: for all errors that are the result of the client making
   a semantic error in their request

2. RefreshError: for all the (uncommon) cases where the server returns
   data that is somehow and unexpectedly invalid.

4. DialError: for any error that occurs when interacting with the SQL
   Admin API or when attempting to connect to a
   particular SQL instance.

By providing concrete errors or wrapping concrete errors, we allow our
clients to uses the errors.As API to possibly react differently to
errors coming out of the dialer.

Fixes #37 